### PR TITLE
Process all pages and don't Liquid-render pages corpus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.o
 *.a
 mkmf.log
+.*.swp

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Join the chat at https://gitter.im/18F/jekyll_pages_api](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/18F/jekyll_pages_api?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-Jekyll Pages API is a [Jekyll Plugin](http://jekyllrb.com/docs/plugins/) gem that generates a JSON file with data for all the Pages in your Site. [Jekyll](http://jekyllrb.com), if you're not familiar, is a static website generator written in Ruby.
+Jekyll Pages API is a [Jekyll Plugin](http://jekyllrb.com/docs/plugins/) gem that generates a JSON file with data for all the Pages, Posts, Documents (i.e. "collections") and StaticFiles in your Site. [Jekyll](http://jekyllrb.com), if you're not familiar, is a static website generator written in Ruby.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,25 @@ You can then see the generated JSON file at http://localhost:4000/api/v1/pages.j
 
 This endpoint will be re-generated any time your site is rebuilt.
 
+## Developing
+
+* Run `bundle` to install any necessary gems.
+* Run `bundle exec rake -T` to get a list of build commands and descriptions.
+* Run `bundle exec rake spec` to run the tests.
+* Run `bundle exec rake build` to ensure the entire gem can build.
+* Commit an update to bump the version number of
+  `lib/jekyll_pages_api/version.rb` before running `bundle exec rake release`.
+
+While developing this gem, add this to the Gemfile of any project using the
+gem to try out your changes (presuming the project's working directory is a
+sibling of the gem's working directory):
+
+```ruby
+group :jekyll_plugins do
+  gem 'jekyll_pages_api', :path => '../jekyll_pages_api'
+end
+```
+
 ## See also
 
 Additional means of turning your site content into data:

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,7 @@
 require "bundler/gem_tasks"
 
+begin
+  require 'rspec/core/rake_task'
+    RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+end

--- a/lib/jekyll_pages_api/generator.rb
+++ b/lib/jekyll_pages_api/generator.rb
@@ -12,10 +12,10 @@ module JekyllPagesApi
     end
 
     def pages
-      result = Array.new
-      self.site.each_site_file do |p|
-        p = Page.new(p, @site)
-        result << p if p.html?
+      result = []
+      self.site.each_site_file do |site_file|
+        page = Page.new(site_file, @site)
+        result << page if page.html?
       end
       result
     end

--- a/lib/jekyll_pages_api/generator.rb
+++ b/lib/jekyll_pages_api/generator.rb
@@ -10,7 +10,12 @@ module JekyllPagesApi
     end
 
     def pages
-      self.site.pages.map{|page| Page.new(page) }.select(&:html?)
+      result = Array.new
+      self.site.each_site_file do |p|
+        p = Page.new(p, @site)
+        result << p if p.html?
+      end
+      result
     end
 
     def pages_data

--- a/lib/jekyll_pages_api/generator.rb
+++ b/lib/jekyll_pages_api/generator.rb
@@ -1,6 +1,8 @@
 require_relative 'page'
 require_relative 'page_without_a_file'
 
+require 'json'
+
 module JekyllPagesApi
   class Generator
     attr_reader :site
@@ -35,10 +37,7 @@ module JekyllPagesApi
     def page
       # based on https://github.com/jekyll/jekyll-sitemap/blob/v0.7.0/lib/jekyll-sitemap.rb#L51-L54
       page = PageWithoutAFile.new(self.site, File.dirname(__FILE__), self.dest_dir, 'pages.json')
-      page.content = self.data.to_json
-      page.data['layout'] = nil
-      page.render(Hash.new, self.site.site_payload)
-
+      page.output = self.data.to_json
       page
     end
 

--- a/lib/jekyll_pages_api/page.rb
+++ b/lib/jekyll_pages_api/page.rb
@@ -3,14 +3,17 @@ require_relative 'filters'
 module JekyllPagesApi
   # wrapper for a Jekyll::Page
   class Page
+    HTML_EXTS = %w(.html .md .markdown .textile)
     attr_reader :page
 
-    def initialize(page)
+    def initialize(page, site)
       @page = page
+      @site = site
     end
 
     def html?
-      %w(.html .md).include?(self.page.ext)
+      path = @page.path
+      path.end_with?('/') || HTML_EXTS.include?(File.extname(path))
     end
 
     def filterer
@@ -18,23 +21,31 @@ module JekyllPagesApi
     end
 
     def title
-      self.filterer.decode_html(self.page.data['title'] || '')
+      title = self.page.data['title'] if self.page.respond_to?(:data)
+      title = self.page.title if title == nil and self.page.respond_to?(:title)
+      self.filterer.decode_html(title || '')
     end
 
     def base_url
-      self.page.site.baseurl
+      @site.baseurl
     end
 
     def url
-      [self.base_url, self.page.url].join
+      rel_path = self.page.url if self.page.respond_to?(:url)
+      if rel_path == nil and self.page.respond_to?(:relative_path)
+        rel_path = self.page.relative_path
+      end
+      [self.base_url, rel_path].join
     end
 
     def body_text
-      self.filterer.text_only(self.page.content)
+      output = self.page.content if self.page.respond_to?(:content)
+      File.open(self.page.path, 'r') {|f| output = f.read} if output == nil
+      self.filterer.text_only(output)
     end
 
     def tags
-      self.page.data['tags'] || []
+      (self.page.data['tags'] if self.page.respond_to?(:data)) || []
     end
 
     def to_json

--- a/lib/jekyll_pages_api/version.rb
+++ b/lib/jekyll_pages_api/version.rb
@@ -1,3 +1,3 @@
 module JekyllPagesApi
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end

--- a/lib/jekyll_pages_api/version.rb
+++ b/lib/jekyll_pages_api/version.rb
@@ -1,3 +1,3 @@
 module JekyllPagesApi
-  VERSION = '0.1.3'
+  VERSION = '0.1.2'
 end

--- a/lib/jekyll_pages_api/version.rb
+++ b/lib/jekyll_pages_api/version.rb
@@ -1,3 +1,3 @@
 module JekyllPagesApi
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -12,8 +12,12 @@ describe "integration" do
     JSON.parse(contents)
   end
 
+  def pages_data
+    @json ||= read_json(JSON_PATH)
+  end
+
   def entries_data
-    (@json ||= read_json(JSON_PATH))['entries']
+    pages_data['entries']
   end
 
   def page_data(url)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -45,12 +45,14 @@ describe "integration" do
     # not sure why this discrepancy exists...
     if Jekyll::VERSION.start_with?('3.')
       expect(urls).to eq(%w(
+        /jekyll/update/2015/01/25/welcome-to-jekyll.html
         /about/
         /
         /unicode.html
       ))
     else
       expect(urls).to eq(%w(
+        /jekyll/update/2015/01/25/welcome-to-jekyll.html
         /about/
         /index.html
         /unicode.html

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -44,7 +44,7 @@ describe "integration" do
     # not sure why this discrepancy exists...
     if Jekyll::VERSION.start_with?('3.')
       expect(urls).to eq(%w(
-        /jekyll/update/2015/01/25/welcome-to-jekyll.html
+        /jekyll/update/2015/01/26/welcome-to-jekyll.html
         /jekyll/update/2015/05/25/do-not-render-result.html
         /about/
         /
@@ -52,7 +52,7 @@ describe "integration" do
       ))
     else
       expect(urls).to eq(%w(
-        /jekyll/update/2015/01/25/welcome-to-jekyll.html
+        /jekyll/update/2015/01/26/welcome-to-jekyll.html
         /jekyll/update/2015/05/25/do-not-render-result.html
         /about/
         /index.html

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -13,8 +13,7 @@ describe "integration" do
   end
 
   def entries_data
-    json = read_json(JSON_PATH)
-    json['entries']
+    (@json ||= read_json(JSON_PATH))['entries']
   end
 
   def page_data(url)
@@ -46,6 +45,7 @@ describe "integration" do
     if Jekyll::VERSION.start_with?('3.')
       expect(urls).to eq(%w(
         /jekyll/update/2015/01/25/welcome-to-jekyll.html
+        /jekyll/update/2015/05/25/do-not-render-result.html
         /about/
         /
         /unicode.html
@@ -53,6 +53,7 @@ describe "integration" do
     else
       expect(urls).to eq(%w(
         /jekyll/update/2015/01/25/welcome-to-jekyll.html
+        /jekyll/update/2015/05/25/do-not-render-result.html
         /about/
         /index.html
         /unicode.html
@@ -60,11 +61,13 @@ describe "integration" do
     end
   end
 
-  it "removes liquid tags" do
-    entries_data.each do |page|
-      expect(page['body']).to_not include('{%')
-      expect(page['body']).to_not include('{{')
-    end
+  it "does not render the pages corpus using Liquid" do
+    # The content of each page in the pages corpus should be Liquid-rendered,
+    # but rendering the pages.json corpus may cause pages that contain code
+    # examples of Liquid tags may produce invalid JSON.
+    page = page_data '/jekyll/update/2015/05/25/do-not-render-result.html'
+    expect(page['body']).to_not include('{% raw %}')
+    expect(page['body']).to include('{% author chrisc %}')
   end
 
   it "removes HTML tags" do

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -1,19 +1,149 @@
+BASEURL = Jekyll::Configuration::DEFAULTS['baseurl']
+
+RSpec.shared_context "create page" do
+  before { @tmp_dir = '' }
+  after { FileUtils.remove_entry(@tmp_dir) if not @tmp_dir.empty? }
+
+  def create_page(baseurl, page_url, data: nil, content: nil)
+    site = instance_double(Jekyll::Site, baseurl: baseurl)
+    jekyll_page = instance_double(Jekyll::Page, site: site, url: page_url,
+      path: page_url)
+    allow(jekyll_page).to receive(:data).and_return(data) unless data == nil
+    unless content == nil
+      allow(jekyll_page).to receive(:content).and_return(content)
+    end
+    JekyllPagesApi::Page.new(jekyll_page, site)
+  end
+
+  def create_static_file(baseurl, relative_path, content: nil)
+    site = instance_double(Jekyll::Site, baseurl: baseurl)
+    if content == nil
+      jekyll_static_file = instance_double(Jekyll::StaticFile,
+        relative_path: relative_path)
+    else content == nil
+      @tmp_root = Dir.mktmpdir
+      @static_file_path = File.join(@tmp_root, relative_path)
+      FileUtils.mkdir_p(File.dirname(@static_file_path))
+      File.open(@static_file_path, 'w') {|f| f << content}
+
+      jekyll_static_file = Jekyll::StaticFile.new(site, @tmp_root,
+        File.dirname(relative_path), File.basename(relative_path))
+    end
+    JekyllPagesApi::Page.new(jekyll_static_file, site)
+  end
+
+  def create_post(baseurl, page_url, data: nil, title: nil)
+    site = instance_double(Jekyll::Site, baseurl: baseurl)
+    jekyll_post = instance_double(Jekyll::Post, site: site, url: page_url,
+      path: page_url)
+    allow(jekyll_post).to receive(:data).and_return(data) unless data == nil
+    allow(jekyll_post).to receive(:title).and_return(title) unless title == nil
+    JekyllPagesApi::Page.new(jekyll_post, site)
+  end
+
+  def create_document(baseurl, relative_path, data: nil)
+    site = instance_double(Jekyll::Site, baseurl: baseurl)
+    jekyll_doc = instance_double(Jekyll::Document, relative_path: relative_path)
+    allow(jekyll_doc).to receive(:data).and_return(data) unless data == nil
+    JekyllPagesApi::Page.new(jekyll_doc, site)
+  end
+end
+
 describe JekyllPagesApi::Page do
+  include_context "create page"
+
   describe '#url' do
     it "returns the path" do
-      site = instance_double(Jekyll::Site, baseurl: Jekyll::Configuration::DEFAULTS['baseurl'])
-      jekyll_page = instance_double(Jekyll::Page, site: site, url: '/foo/')
-      page = JekyllPagesApi::Page.new(jekyll_page)
-
-      expect(page.url).to eq('/foo/')
+      expect(create_page(BASEURL, '/foo/').url).to eq('/foo/')
     end
 
     it "prepends the baseurl" do
-      site = instance_double(Jekyll::Site, baseurl: '/base')
-      jekyll_page = instance_double(Jekyll::Page, site: site, url: '/foo/')
-      page = JekyllPagesApi::Page.new(jekyll_page)
+      expect(create_page('/base', '/foo/').url).to eq('/base/foo/')
+    end
 
-      expect(page.url).to eq('/base/foo/')
+    it "uses the relative path for StaticFiles" do
+      page = create_static_file('/base', '/foo.html')
+      expect(page.url).to eq('/base/foo.html')
+    end
+
+    it "uses the relative path for Documents" do
+      expect(create_document('/base', '/foo.html').url).to eq('/base/foo.html')
+    end
+  end
+
+  describe '#html?' do
+    it "returns true for paths ending in slash" do
+      expect(create_page(BASEURL, '/foo/').html?).to eq(true)
+    end
+
+    it "returns true for paths ending in .html" do
+      expect(create_page(BASEURL, '/foo/index.html').html?).to eq(true)
+    end
+
+    it "returns true for paths ending in .md" do
+      expect(create_page(BASEURL, '/foo/index.html').html?).to eq(true)
+    end
+
+    it "returns false otherwise" do
+      expect(create_page(BASEURL, '/foo/index.json').html?).to eq(false)
+    end
+  end
+
+  describe '#title' do
+    it "returns the title field from the page's front matter if present" do
+      page = create_page(BASEURL, '/foo/', data:{'title' => 'Foo'})
+      expect(page.title).to eq('Foo')
+    end
+
+    it "returns the title field from the post's front matter if present" do
+      page = create_post(BASEURL, '/foo/', data:{'title' => 'Foo'})
+      expect(page.title).to eq('Foo')
+    end
+
+    it "returns the title method from post method if not in front matter" do
+      page = create_post(BASEURL, '/foo/', title: 'Foo')
+      expect(page.title).to eq('Foo')
+    end
+
+    it "returns the empty string for StaticFiles" do
+      expect(create_static_file(BASEURL, '/foo/').title).to eq('')
+    end
+
+    it "returns the title field from the document's front matter if present" do
+      page = create_document(BASEURL, '/foo/', data:{'title' => 'Foo'})
+      expect(page.title).to eq('Foo')
+    end
+
+    it "returns the empty string for Documents if not in front matter" do
+      expect(create_document(BASEURL, '/foo/').title).to eq('')
+    end
+  end
+
+  describe "#tags" do
+    it "returns tags if present in the front matter" do
+      page = create_page(BASEURL, '/foo/',
+        data:{'tags' => ['foo', 'bar', 'baz']})
+      expect(page.tags).to eq(['foo', 'bar', 'baz'])
+    end
+
+    it "returns the empty list if not present in the front matter" do
+      expect(create_page(BASEURL, '/foo/').tags).to eq([])
+    end
+
+    it "returns the empty list if the page does not contain front matter" do
+      expect(create_static_file(BASEURL, '/foo/').tags).to eq([])
+    end
+  end
+
+  describe "#body_text" do
+    it "returns the content if present" do
+      page = create_page(BASEURL, '/foo/', content: "foo bar baz")
+      expect(page.body_text).to eq("foo bar baz")
+    end
+
+    it "returns the file content of StaticFiles" do
+      page = create_static_file(BASEURL, '/foo.html', content: "foo bar baz")
+      expect(page.body_text).to eq("foo bar baz")
     end
   end
 end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -1,55 +1,6 @@
-require 'tmpdir'
+require_relative 'support/create_page'
 
 BASEURL = Jekyll::Configuration::DEFAULTS['baseurl']
-
-RSpec.shared_context "create page" do
-  before { @tmp_dir = '' }
-  after { FileUtils.remove_entry(@tmp_dir) if not @tmp_dir.empty? }
-
-  def create_page(baseurl, page_url, data: nil, content: nil)
-    site = instance_double(Jekyll::Site, baseurl: baseurl)
-    jekyll_page = instance_double(Jekyll::Page, site: site, url: page_url,
-      path: page_url)
-    allow(jekyll_page).to receive(:data).and_return(data) unless data == nil
-    unless content == nil
-      allow(jekyll_page).to receive(:content).and_return(content)
-    end
-    JekyllPagesApi::Page.new(jekyll_page, site)
-  end
-
-  def create_static_file(baseurl, relative_path, content: nil)
-    site = instance_double(Jekyll::Site, baseurl: baseurl)
-    if content == nil
-      jekyll_static_file = instance_double(Jekyll::StaticFile,
-        relative_path: relative_path)
-    else content == nil
-      @tmp_root = Dir.mktmpdir
-      @static_file_path = File.join(@tmp_root, relative_path)
-      FileUtils.mkdir_p(File.dirname(@static_file_path))
-      File.open(@static_file_path, 'w') {|f| f << content}
-
-      jekyll_static_file = Jekyll::StaticFile.new(site, @tmp_root,
-        File.dirname(relative_path), File.basename(relative_path))
-    end
-    JekyllPagesApi::Page.new(jekyll_static_file, site)
-  end
-
-  def create_post(baseurl, page_url, data: nil, title: nil)
-    site = instance_double(Jekyll::Site, baseurl: baseurl)
-    jekyll_post = instance_double(Jekyll::Post, site: site, url: page_url,
-      path: page_url)
-    allow(jekyll_post).to receive(:data).and_return(data) unless data == nil
-    allow(jekyll_post).to receive(:title).and_return(title) unless title == nil
-    JekyllPagesApi::Page.new(jekyll_post, site)
-  end
-
-  def create_document(baseurl, relative_path, data: nil)
-    site = instance_double(Jekyll::Site, baseurl: baseurl)
-    jekyll_doc = instance_double(Jekyll::Document, relative_path: relative_path)
-    allow(jekyll_doc).to receive(:data).and_return(data) unless data == nil
-    JekyllPagesApi::Page.new(jekyll_doc, site)
-  end
-end
 
 describe JekyllPagesApi::Page do
   include_context "create page"

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -1,3 +1,5 @@
+require 'tmpdir'
+
 BASEURL = Jekyll::Configuration::DEFAULTS['baseurl']
 
 RSpec.shared_context "create page" do

--- a/spec/site/_posts/2015-01-26-welcome-to-jekyll.markdown
+++ b/spec/site/_posts/2015-01-26-welcome-to-jekyll.markdown
@@ -1,7 +1,6 @@
 ---
 layout: post
 title:  "Welcome to Jekyll!"
-date:   2015-01-26 02:53:40
 categories: jekyll update
 ---
 You’ll find this post in your `_posts` directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run `jekyll serve`, which launches a web server and auto-regenerates your site when a file is updated.

--- a/spec/site/_posts/2015-05-25-do-not-render-result.markdown
+++ b/spec/site/_posts/2015-05-25-do-not-render-result.markdown
@@ -1,0 +1,14 @@
+---
+layout: post
+title:  "Do Not Render the Result"
+categories: jekyll update
+---
+Sometimes posts will contain examples of Liquid code, like this from the [18F blog post about Jekyll and webhooks](https://18f.gsa.gov/2014/11/17/taking-control-of-our-website-with-jekyll-and-webhooks/):
+
+```html
+<p class="authors">
+  by {% raw %}{% author chrisc %}{% endraw %}, {%raw %}{% author mhz %}{% endraw %}, and {% raw %}{% author nick %}{% endraw %}
+</p>
+```
+
+If we render the `pages.json` corpus, the Liquid tags will generate text that is not properly JSON-escaped, rendering the corpus as invalid JSON.

--- a/spec/support/create_page.rb
+++ b/spec/support/create_page.rb
@@ -1,0 +1,50 @@
+require 'tmpdir'
+
+RSpec.shared_context "create page" do
+  before { @tmp_dir = nil }
+  after { FileUtils.remove_entry(@tmp_dir) if @tmp_dir }
+
+  def create_page(baseurl, page_url, data: nil, content: nil)
+    site = instance_double(Jekyll::Site, baseurl: baseurl)
+    jekyll_page = instance_double(Jekyll::Page, site: site, url: page_url,
+      path: page_url)
+    allow(jekyll_page).to receive(:data).and_return(data) unless data.nil?
+    unless content.nil?
+      allow(jekyll_page).to receive(:content).and_return(content)
+    end
+    JekyllPagesApi::Page.new(jekyll_page, site)
+  end
+
+  def create_static_file(baseurl, relative_path, content: nil)
+    site = instance_double(Jekyll::Site, baseurl: baseurl)
+    if content.nil?
+      jekyll_static_file = instance_double(Jekyll::StaticFile,
+        relative_path: relative_path)
+    else content.nil?
+      @tmp_root = Dir.mktmpdir
+      @static_file_path = File.join(@tmp_root, relative_path)
+      FileUtils.mkdir_p(File.dirname(@static_file_path))
+      File.open(@static_file_path, 'w') {|f| f << content}
+
+      jekyll_static_file = Jekyll::StaticFile.new(site, @tmp_root,
+        File.dirname(relative_path), File.basename(relative_path))
+    end
+    JekyllPagesApi::Page.new(jekyll_static_file, site)
+  end
+
+  def create_post(baseurl, page_url, data: nil, title: nil)
+    site = instance_double(Jekyll::Site, baseurl: baseurl)
+    jekyll_post = instance_double(Jekyll::Post, site: site, url: page_url,
+      path: page_url)
+    allow(jekyll_post).to receive(:data).and_return(data) unless data.nil?
+    allow(jekyll_post).to receive(:title).and_return(title) unless title.nil?
+    JekyllPagesApi::Page.new(jekyll_post, site)
+  end
+
+  def create_document(baseurl, relative_path, data: nil)
+    site = instance_double(Jekyll::Site, baseurl: baseurl)
+    jekyll_doc = instance_double(Jekyll::Document, relative_path: relative_path)
+    allow(jekyll_doc).to receive(:data).and_return(data) unless data.nil?
+    JekyllPagesApi::Page.new(jekyll_doc, site)
+  end
+end


### PR DESCRIPTION
This is really two PRs in one, motivated by my work to build [18F/jekyll_pages_api_search](https://github.com/18F/jekyll_pages_api_search/). First, it adds Posts, Documents, and StaticFiles to the pages corpus. Second, it prevents the resulting `pages.json` corpus from being rendered by Liquid.

I noticed the need for these features when experimenting with interating the jekyll_pages_api_search plugin into [18F/18f.gsa.gov](https://github.com/18F/18f.gsa.gov/). The absence of Posts from the corpus made the search less useful; then the presence of example Liquid markup in the [Jekyll and webhooks post](https://18f.gsa.gov/2014/11/17/taking-control-of-our-website-with-jekyll-and-webhooks/) caused the `pages.json` file to be invalid JSON due to rendering the corpus with Liquid, rather than just assigning the JSON output directly to `page.output`.

With these changes, I'm able to build and integrate search indexes both into 18f.gsa.gov and the [18F/hub](https://github.com/18F/hub/).

cc: @afeld