### PR TITLE
Support optional should_index attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ You can then see the generated JSON file at http://localhost:4000/api/v1/pages.j
 
 This endpoint will be re-generated any time your site is rebuilt.
 
+### Skipping the index
+
+The [Jekyll Pages API Search plugin](https://github.com/18F/jekyll_pages_api_search) uses this plugin to build a search index. Add `skip_index: true` to the front matter of any documents you wish to exclude from this index.
+
 ## Developing
 
 * Run `bundle` to install any necessary gems.

--- a/lib/jekyll_pages_api/page.rb
+++ b/lib/jekyll_pages_api/page.rb
@@ -52,13 +52,20 @@ module JekyllPagesApi
       (self.page.data['tags'] if self.page.respond_to?(:data)) || []
     end
 
+    def should_index?
+      result = self.page.data['should_index'] if self.page.respond_to?(:data)
+      result.nil? || result
+    end
+
     def to_json
-      {
+      optional = {}
+      optional['should_index'] = false unless self.should_index?
+      optional.merge({
         title: self.title,
         url: self.url,
         tags: self.tags,
         body: self.body_text
-      }
+      })
     end
   end
 end

--- a/lib/jekyll_pages_api/page.rb
+++ b/lib/jekyll_pages_api/page.rb
@@ -52,14 +52,13 @@ module JekyllPagesApi
       (self.page.data['tags'] if self.page.respond_to?(:data)) || []
     end
 
-    def should_index?
-      result = self.page.data['should_index'] if self.page.respond_to?(:data)
-      result.nil? || result
+    def skip_index?
+      (self.page.data['skip_index'] if self.page.respond_to?(:data)) || false
     end
 
     def to_json
       optional = {}
-      optional['should_index'] = false unless self.should_index?
+      optional['skip_index'] = true if self.skip_index?
       optional.merge({
         title: self.title,
         url: self.url,

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -95,4 +95,11 @@ describe "integration" do
     page = page_data('/about/')
     expect(page['tags']).to eq(["Jekyll", "test page", "convenient"])
   end
+
+  it "sets should_index only if it is false" do
+    page = page_data('/about/')
+    expect(page['should_index']).to eq(false)
+    page = page_data('/index.html')
+    expect(page['should_index']).to eq(nil)
+  end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -96,10 +96,10 @@ describe "integration" do
     expect(page['tags']).to eq(["Jekyll", "test page", "convenient"])
   end
 
-  it "sets should_index only if it is false" do
+  it "sets skip_index only if it is true" do
     page = page_data('/about/')
-    expect(page['should_index']).to eq(false)
-    page = page_data('/index.html')
-    expect(page['should_index']).to eq(nil)
+    expect(page['skip_index']).to eq(true)
+    page = page_data('/unicode.html')
+    expect(page['skip_index']).to eq(nil)
   end
 end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -100,18 +100,18 @@ describe JekyllPagesApi::Page do
     end
   end
 
-  describe "#should_index?" do
-    it "defaults to true if the 'data' member isn't present" do
-      expect(create_static_file(BASEURL, '/foo/').should_index?).to eq(true)
+  describe "#skip_index?" do
+    it "defaults to false if the 'data' member isn't present" do
+      expect(create_static_file(BASEURL, '/foo/').skip_index?).to eq(false)
     end
 
-    it "defaults to true if the 'should_index' field isn't present" do
-      expect(create_page(BASEURL, '/foo/').should_index?).to eq(true)
+    it "defaults to false if the 'skip_index' field isn't present" do
+      expect(create_page(BASEURL, '/foo/').skip_index?).to eq(false)
     end
 
-    it "returns false if data['should_index'] is false" do
-      page = create_page(BASEURL, '/foo/', data:{'should_index' => false})
-      expect(page.should_index?).to eq(false)
+    it "returns true if data['skip_index'] is true" do
+      page = create_page(BASEURL, '/foo/', data:{'skip_index' => true})
+      expect(page.skip_index?).to eq(true)
     end
   end
 end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -99,4 +99,19 @@ describe JekyllPagesApi::Page do
       expect(page.body_text).to eq("foo bar baz")
     end
   end
+
+  describe "#should_index?" do
+    it "defaults to true if the 'data' member isn't present" do
+      expect(create_static_file(BASEURL, '/foo/').should_index?).to eq(true)
+    end
+
+    it "defaults to true if the 'should_index' field isn't present" do
+      expect(create_page(BASEURL, '/foo/').should_index?).to eq(true)
+    end
+
+    it "returns false if data['should_index'] is false" do
+      page = create_page(BASEURL, '/foo/', data:{'should_index' => false})
+      expect(page.should_index?).to eq(false)
+    end
+  end
 end

--- a/spec/site/about.md
+++ b/spec/site/about.md
@@ -6,6 +6,7 @@ tags:
 - Jekyll
 - test page
 - convenient
+should_index: false
 ---
 
 This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](http://jekyllrb.com/)

--- a/spec/site/about.md
+++ b/spec/site/about.md
@@ -6,7 +6,7 @@ tags:
 - Jekyll
 - test page
 - convenient
-should_index: false
+skip_index: true
 ---
 
 This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](http://jekyllrb.com/)


### PR DESCRIPTION
The intent is to prevent certain documents from being included in the search corpus by the [jekyll_pages_api_search plugin](https://github.com/18F/jekyll_pages_api_search).

cc: @afeld 