### PR TITLE
Standalone executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ This endpoint will be re-generated any time your site is rebuilt.
 
 The [Jekyll Pages API Search plugin](https://github.com/18F/jekyll_pages_api_search) uses this plugin to build a search index. Add `skip_index: true` to the front matter of any documents you wish to exclude from this index.
 
+### Running standalone
+
+If you wish to generate a `pages.json` file when using a site generation tool other than Jekyll, you can run the `jekyll_pages_api` executable as a post-generation step. Run `jekyll_pages_api -h` for instructions.
+
 ## Developing
 
 * Run `bundle` to install any necessary gems.

--- a/bin/jekyll_pages_api
+++ b/bin/jekyll_pages_api
@@ -1,0 +1,158 @@
+#! /usr/bin/env ruby
+# Author: Mike Bland <michael.bland@gsa.gov>
+# Date:   2015-06-21
+
+require_relative '../lib/jekyll_pages_api'
+
+module JekyllPagesApi
+  class GeneratedSite
+    attr_reader :baseurl, :basedir, :title_prefix, :body_element
+    attr_accessor :pages
+
+    def initialize(baseurl, basedir, title_prefix, body_element)
+      @baseurl = baseurl
+      @basedir = basedir
+      @title_prefix = title_prefix
+      @body_element = body_element
+      @pages = Array.new
+    end
+
+    def each_site_file
+      Dir[File.join self.basedir, '**', '*'].each do |f|
+        next unless f.end_with? '.html'
+        begin
+          page = GeneratedPage.new(self.basedir, f)
+          page.parse self.title_prefix, self.body_element
+          yield page unless page.data['title'].nil?
+        rescue
+          $stderr.puts "Error processing #{f}"
+          raise
+        end
+      end
+    end
+  end
+
+  class GeneratedPage
+    attr_reader :path, :relative_path, :data, :content
+
+    def initialize(basedir, path)
+      @path = path
+      basedir_len = basedir.size
+      basedir_len += 1 if basedir.end_with? File::SEPARATOR
+
+      end_path = path.size
+      index_suffix = File.join "", "index.html"
+      end_path -= (index_suffix.size + 1) if path.end_with? index_suffix
+      @relative_path = path[basedir_len..end_path]
+      @data = Hash.new
+      @content = nil
+    end
+
+    def parse(title_prefix, body_element)
+      @content = File.read(self.path)
+      head_section = parse_basic_tag 'head', content
+      return if head_section.nil?
+
+      title = parse_title_from_head head_section
+      if !title.nil? && title.start_with?(title_prefix)
+        title = title[title_prefix.size..title.size]
+      end
+      self.data['title'] = title
+      parse_meta_tags head_section
+      parse_body body_element
+    end
+
+    private
+
+    def parse_basic_tag(tag_name, s)
+      open_tag = "<#{tag_name}"
+      close_tag = "</#{tag_name}>"
+      open_i = s.index open_tag
+      return nil if open_i.nil?
+      open_i = s.index '>', open_i + open_tag.size
+      close_i = s.index(close_tag, open_i)
+      return nil if close_i.nil?
+      close_i -= 1
+      return s[open_i..close_i]
+    end
+
+    def parse_title_from_head(head_section)
+      return parse_basic_tag 'title', head_section unless head_section.nil?
+    end
+
+    def parse_meta_tags(s)
+      open_tag = "<meta "
+      open_i = s.index open_tag
+
+      until open_i.nil? do
+        open_i += open_tag.size
+        close_i = s.index '>', open_i
+        return if close_i.nil?
+
+        current = s[open_i..close_i]
+        attrs = {'name' => nil, 'content' => nil}
+
+        attrs.keys.each do |attr|
+          attr_begin = "#{attr}="
+          attr_begin_i = current.index attr_begin
+          unless attr_begin_i.nil?
+            attr_begin_i += attr_begin.size + 1
+            delim = s[attr_begin_i-1]
+            attr_end_i = s.index delim, attr_begin_i
+            next if attr_end_i.nil?
+            attrs[attr] = current[attr_begin_i..attr_end_i]
+          end
+        end
+        meta_name = attrs['name']
+        self.data[meta_name] = attrs['content'] unless meta_name.nil?
+        close_i += 1
+        open_i = s.index open_tag, close_i
+      end
+    end
+
+    def parse_body(body_element)
+      @content = parse_basic_tag 'body', @content
+      start_body = @content.index body_element
+      return if start_body.nil?
+      body = @content
+
+      start_body += 1
+      end_name_i = body.index ' ', start_body
+      bracket_i = body.index '>', start_body
+      end_name_i = bracket_i if bracket_i < end_name_i
+      tag_name = body[start_body..end_name_i-1]
+      open_tag = "<#{tag_name}"
+      end_tag = "</#{tag_name}>"
+
+      start_body = bracket_i + 1
+      search_i = start_body
+      depth = 1
+      until depth == 0
+        open_tag_i = body.index open_tag, search_i
+        end_tag_i = body.index end_tag, search_i
+        if end_tag_i.nil?
+          raise "End tag missing: #{end_tag}"
+        end
+        if !open_tag.nil? && open_tag_i < end_tag_i
+          depth += 1
+          search_i = open_tag_i + open_tag.size
+        else
+          depth -= 1
+          search_i = end_tag_i + end_tag.size
+        end
+      end
+      @content = body[start_body..end_tag_i]
+    end
+  end
+end
+
+if ARGV.length != 4
+  $stderr.puts "Usage: #{$0} baseurl basedir title_prefix body_element"
+  exit 1
+end
+
+baseurl, basedir, title_prefix, body_element = ARGV
+generator = ::JekyllPagesApi::Generator.new(
+  ::JekyllPagesApi::GeneratedSite.new(
+    baseurl, basedir, title_prefix, body_element))
+puts generator.page.output

--- a/bin/jekyll_pages_api
+++ b/bin/jekyll_pages_api
@@ -69,11 +69,10 @@ module JekyllPagesApi
       close_tag = "</#{tag_name}>"
       open_i = s.index open_tag
       return nil if open_i.nil?
-      open_i = s.index '>', open_i + open_tag.size
-      close_i = s.index(close_tag, open_i)
+      open_i = s.index('>', open_i + open_tag.size) + 1
+      close_i = s.index close_tag, open_i
       return nil if close_i.nil?
-      close_i -= 1
-      return s[open_i..close_i]
+      return s[open_i..close_i-1]
     end
 
     def parse_title_from_head(head_section)
@@ -144,7 +143,7 @@ module JekyllPagesApi
           end_tag_i = body.index end_tag, search_i unless depth == 0
         end
       end
-      @content = body[start_body..end_tag_i]
+      @content = body[start_body..end_tag_i-1]
     end
   end
 end

--- a/bin/jekyll_pages_api
+++ b/bin/jekyll_pages_api
@@ -14,11 +14,11 @@ module JekyllPagesApi
       @basedir = basedir
       @title_prefix = title_prefix
       @body_element = body_element
-      @pages = Array.new
+      @pages = []
     end
 
     def each_site_file
-      Dir[File.join self.basedir, '**', '*'].each do |f|
+      Dir.glob(File.join(self.basedir, '**', '*')) do |f|
         next unless f.end_with? '.html'
         begin
           page = GeneratedPage.new(self.basedir, f)
@@ -50,45 +50,45 @@ module JekyllPagesApi
 
     def parse(title_prefix, body_element)
       @content = File.read(self.path)
-      head_section = parse_basic_tag 'head', content
-      return if head_section.nil?
+      head_element = parse_basic_tag 'head', content
+      return if head_element.nil?
 
-      title = parse_title_from_head head_section
+      title = parse_title_from_head head_element
       if !title.nil? && title.start_with?(title_prefix)
         title = title[title_prefix.size..title.size]
       end
       self.data['title'] = title
-      parse_meta_tags head_section
+      parse_meta_tags head_element
       parse_body body_element
     end
 
     private
 
-    def parse_basic_tag(tag_name, s)
+    def parse_basic_tag(tag_name, content)
       open_tag = "<#{tag_name}"
       close_tag = "</#{tag_name}>"
-      open_i = s.index open_tag
+      open_i = content.index open_tag
       return nil if open_i.nil?
-      open_i = s.index('>', open_i + open_tag.size) + 1
-      close_i = s.index close_tag, open_i
+      open_i = content.index('>', open_i + open_tag.size) + 1
+      close_i = content.index close_tag, open_i
       return nil if close_i.nil?
-      return s[open_i..close_i-1]
+      return content[open_i..close_i-1]
     end
 
-    def parse_title_from_head(head_section)
-      return parse_basic_tag 'title', head_section unless head_section.nil?
+    def parse_title_from_head(head_element)
+      return parse_basic_tag 'title', head_element unless head_element.nil?
     end
 
-    def parse_meta_tags(s)
+    def parse_meta_tags(head_element)
       open_tag = "<meta "
-      open_i = s.index open_tag
+      open_i = head_element.index open_tag
 
       until open_i.nil? do
         open_i += open_tag.size
-        close_i = s.index '>', open_i
+        close_i = head_element.index '>', open_i
         return if close_i.nil?
 
-        current = s[open_i..close_i]
+        current = head_element[open_i..close_i]
         attrs = {'name' => nil, 'content' => nil}
 
         attrs.keys.each do |attr|
@@ -106,7 +106,7 @@ module JekyllPagesApi
         meta_name = attrs['name']
         self.data[meta_name] = attrs['content'] unless meta_name.nil?
         close_i += 1
-        open_i = s.index open_tag, close_i
+        open_i = head_element.index open_tag, close_i
       end
     end
 

--- a/bin/jekyll_pages_api
+++ b/bin/jekyll_pages_api
@@ -127,19 +127,21 @@ module JekyllPagesApi
 
       start_body = bracket_i + 1
       search_i = start_body
+      open_tag_i = body.index open_tag, search_i
+      end_tag_i = body.index end_tag, search_i
       depth = 1
       until depth == 0
-        open_tag_i = body.index open_tag, search_i
-        end_tag_i = body.index end_tag, search_i
         if end_tag_i.nil?
           raise "End tag missing: #{end_tag}"
         end
         if !open_tag.nil? && open_tag_i < end_tag_i
           depth += 1
           search_i = open_tag_i + open_tag.size
+          open_tag_i = body.index open_tag, search_i
         else
           depth -= 1
           search_i = end_tag_i + end_tag.size
+          end_tag_i = body.index end_tag, search_i unless depth == 0
         end
       end
       @content = body[start_body..end_tag_i]

--- a/bin/jekyll_pages_api
+++ b/bin/jekyll_pages_api
@@ -97,9 +97,10 @@ module JekyllPagesApi
           attr_begin_i = current.index attr_begin
           unless attr_begin_i.nil?
             attr_begin_i += attr_begin.size + 1
-            delim = s[attr_begin_i-1]
-            attr_end_i = s.index delim, attr_begin_i
+            delim = current[attr_begin_i-1]
+            attr_end_i = current.index delim, attr_begin_i
             next if attr_end_i.nil?
+            attr_end_i -= 1
             attrs[attr] = current[attr_begin_i..attr_end_i]
           end
         end

--- a/bin/jekyll_pages_api
+++ b/bin/jekyll_pages_api
@@ -21,9 +21,10 @@ Arguments:
   title_prefix
     Prefix to strip from page titles
   body_element_tag
-    Tag (or tag prefix) identifying the main content element of each tag. Can
-    be a complete tag (ending in '>'), or the prefix of a longer tag. Used to
-    strip boilerplate out of the content exported via the API.
+    Tag (or tag prefix) identifying the main content element within the <body>
+    element of each document. Can be a complete tag (ending in '>'), or the
+    prefix of a longer tag. Used to strip boilerplate out of the content
+    exported via the API.
 END_USAGE
 
 if ARGV.length == 1 && ARGV[0] == '-h'

--- a/bin/jekyll_pages_api
+++ b/bin/jekyll_pages_api
@@ -4,157 +4,45 @@
 
 require_relative '../lib/jekyll_pages_api'
 
-module JekyllPagesApi
-  class GeneratedSite
-    attr_reader :baseurl, :basedir, :title_prefix, :body_element
-    attr_accessor :pages
+USAGE=<<END_USAGE
+#{$0}: generate Jekyll Pages API output from a pregenerated site
 
-    def initialize(baseurl, basedir, title_prefix, body_element)
-      @baseurl = baseurl
-      @basedir = basedir
-      @title_prefix = title_prefix
-      @body_element = body_element
-      @pages = []
-    end
+Usage:
+  #{$0} baseurl basedir title_prefix body_element_tag > pages.json
+  #{$0} -h
 
-    def each_site_file
-      Dir.glob(File.join(self.basedir, '**', '*')) do |f|
-        next unless f.end_with? '.html'
-        begin
-          page = GeneratedPage.new(self.basedir, f)
-          page.parse self.title_prefix, self.body_element
-          yield page unless page.data['title'].nil?
-        rescue
-          $stderr.puts "Error processing #{f}"
-          raise
-        end
-      end
-    end
-  end
+Arguments:
+  -h
+    Print this help message
+  baseurl
+    URL prefix of every page of the generated site
+  basedir
+    Path to the generated site's root directory
+  title_prefix
+    Prefix to strip from page titles
+  body_element_tag
+    Tag (or tag prefix) identifying the main content element of each tag. Can
+    be a complete tag (ending in '>'), or the prefix of a longer tag. Used to
+    strip boilerplate out of the content exported via the API.
+END_USAGE
 
-  class GeneratedPage
-    attr_reader :path, :relative_path, :data, :content
-
-    def initialize(basedir, path)
-      @path = path
-      basedir_len = basedir.size
-      basedir_len += 1 if basedir.end_with? File::SEPARATOR
-
-      end_path = path.size
-      index_suffix = File.join "", "index.html"
-      end_path -= (index_suffix.size + 1) if path.end_with? index_suffix
-      @relative_path = path[basedir_len..end_path]
-      @data = Hash.new
-      @content = nil
-    end
-
-    def parse(title_prefix, body_element)
-      @content = File.read(self.path)
-      head_element = parse_basic_tag 'head', content
-      return if head_element.nil?
-
-      title = parse_title_from_head head_element
-      if !title.nil? && title.start_with?(title_prefix)
-        title = title[title_prefix.size..title.size]
-      end
-      self.data['title'] = title
-      parse_meta_tags head_element
-      parse_body body_element
-    end
-
-    private
-
-    def parse_basic_tag(tag_name, content)
-      open_tag = "<#{tag_name}"
-      close_tag = "</#{tag_name}>"
-      open_i = content.index open_tag
-      return nil if open_i.nil?
-      open_i = content.index('>', open_i + open_tag.size) + 1
-      close_i = content.index close_tag, open_i
-      return nil if close_i.nil?
-      return content[open_i..close_i-1]
-    end
-
-    def parse_title_from_head(head_element)
-      return parse_basic_tag 'title', head_element unless head_element.nil?
-    end
-
-    def parse_meta_tags(head_element)
-      open_tag = "<meta "
-      open_i = head_element.index open_tag
-
-      until open_i.nil? do
-        open_i += open_tag.size
-        close_i = head_element.index '>', open_i
-        return if close_i.nil?
-
-        current = head_element[open_i..close_i]
-        attrs = {'name' => nil, 'content' => nil}
-
-        attrs.keys.each do |attr|
-          attr_begin = "#{attr}="
-          attr_begin_i = current.index attr_begin
-          unless attr_begin_i.nil?
-            attr_begin_i += attr_begin.size + 1
-            delim = current[attr_begin_i-1]
-            attr_end_i = current.index delim, attr_begin_i
-            next if attr_end_i.nil?
-            attr_end_i -= 1
-            attrs[attr] = current[attr_begin_i..attr_end_i]
-          end
-        end
-        meta_name = attrs['name']
-        self.data[meta_name] = attrs['content'] unless meta_name.nil?
-        close_i += 1
-        open_i = head_element.index open_tag, close_i
-      end
-    end
-
-    def parse_body(body_element)
-      @content = parse_basic_tag 'body', @content
-      start_body = @content.index body_element
-      return if start_body.nil?
-      body = @content
-
-      start_body += 1
-      end_name_i = body.index ' ', start_body
-      bracket_i = body.index '>', start_body
-      end_name_i = bracket_i if bracket_i < end_name_i
-      tag_name = body[start_body..end_name_i-1]
-      open_tag = "<#{tag_name}"
-      end_tag = "</#{tag_name}>"
-
-      start_body = bracket_i + 1
-      search_i = start_body
-      open_tag_i = body.index open_tag, search_i
-      end_tag_i = body.index end_tag, search_i
-      depth = 1
-      until depth == 0
-        if end_tag_i.nil?
-          raise "End tag missing: #{end_tag}"
-        end
-        if !open_tag.nil? && open_tag_i < end_tag_i
-          depth += 1
-          search_i = open_tag_i + open_tag.size
-          open_tag_i = body.index open_tag, search_i
-        else
-          depth -= 1
-          search_i = end_tag_i + end_tag.size
-          end_tag_i = body.index end_tag, search_i unless depth == 0
-        end
-      end
-      @content = body[start_body..end_tag_i-1]
-    end
-  end
+if ARGV.length == 1 && ARGV[0] == '-h'
+  puts USAGE
+  exit
 end
 
 if ARGV.length != 4
-  $stderr.puts "Usage: #{$0} baseurl basedir title_prefix body_element"
+  $stderr.puts USAGE
   exit 1
 end
 
-baseurl, basedir, title_prefix, body_element = ARGV
+baseurl, basedir, title_prefix, body_element_tag = ARGV
+unless Dir.exist?(basedir)
+  $stderr.puts "#{basedir} does not exist"
+  exit 1
+end
+
 generator = ::JekyllPagesApi::Generator.new(
   ::JekyllPagesApi::GeneratedSite.new(
-    baseurl, basedir, title_prefix, body_element))
+    baseurl, basedir, title_prefix, body_element_tag))
 puts generator.page.output

--- a/lib/jekyll_pages_api.rb
+++ b/lib/jekyll_pages_api.rb
@@ -1,2 +1,7 @@
+require 'jekyll_pages_api/filters'
+require 'jekyll_pages_api/generated_site'
+require 'jekyll_pages_api/generator'
+require 'jekyll_pages_api/page'
+require 'jekyll_pages_api/page_without_a_file'
 require 'jekyll_pages_api/version'
 require_relative 'jekyll/site'

--- a/lib/jekyll_pages_api/generated_page.rb
+++ b/lib/jekyll_pages_api/generated_page.rb
@@ -1,0 +1,29 @@
+# @author Mike Bland (michael.bland@gsa.gov)
+
+require_relative 'generated_page_parser'
+
+module JekyllPagesApi
+  # Used by GeneratedSite to mimic a Jekyll page object when processing an
+  # already-generated site using the Generator.
+  class GeneratedPage
+    attr_reader :path, :relative_path, :data, :content
+
+    # @param basedir see {GeneratedSite#initialize}
+    # @param title_prefix see {GeneratedSite#initialize}
+    # @param body_element_tag see {GeneratedSite#initialize}
+    # @param path [String] full path to the generated page's file
+    # @param content [String] HTML content of the generated page's file
+    def initialize(basedir, title_prefix, body_element_tag, path, content)
+      @path = path
+      basedir_len = basedir.size
+      basedir_len += 1 if basedir.end_with? File::SEPARATOR
+
+      end_path = path.size
+      index_suffix = File.join "", "index.html"
+      end_path -= (index_suffix.size + 1) if path.end_with? index_suffix
+      @relative_path = path[basedir_len..end_path]
+      @data, @content = GeneratedPageParser.parse_generated_page(
+        content, title_prefix, body_element_tag)
+    end
+  end
+end

--- a/lib/jekyll_pages_api/generated_page.rb
+++ b/lib/jekyll_pages_api/generated_page.rb
@@ -8,20 +8,25 @@ module JekyllPagesApi
   class GeneratedPage
     attr_reader :path, :relative_path, :data, :content
 
+    # @param path [String] full path to the generated page's file
     # @param basedir see {GeneratedSite#initialize}
     # @param title_prefix see {GeneratedSite#initialize}
     # @param body_element_tag see {GeneratedSite#initialize}
-    # @param path [String] full path to the generated page's file
     # @param content [String] HTML content of the generated page's file
-    def initialize(basedir, title_prefix, body_element_tag, path, content)
+    # @raises [RuntimError] if path does not begin with basedir
+    def initialize(path, basedir, title_prefix, body_element_tag, content)
+      unless path.start_with? basedir
+        raise "#{path} does not start with #{basedir}"
+      end
+
       @path = path
       basedir_len = basedir.size
-      basedir_len += 1 if basedir.end_with? File::SEPARATOR
+      basedir_len -= File::SEPARATOR.size if basedir.end_with? File::SEPARATOR
 
       end_path = path.size
       index_suffix = File.join "", "index.html"
-      end_path -= (index_suffix.size + 1) if path.end_with? index_suffix
-      @relative_path = path[basedir_len..end_path]
+      end_path -= index_suffix.size if path.end_with? index_suffix
+      @relative_path = (path[basedir_len..end_path] || "")
       @data, @content = GeneratedPageParser.parse_generated_page(
         content, title_prefix, body_element_tag)
     end

--- a/lib/jekyll_pages_api/generated_page_parser.rb
+++ b/lib/jekyll_pages_api/generated_page_parser.rb
@@ -1,0 +1,119 @@
+# @author Mike Bland (michael.bland@gsa.gov)
+
+module JekyllPagesApi
+  # Contains helper methods for parsing values from HTML.
+  class GeneratedPageParser
+    # Parses elements from a generated page's content needed by GeneratedPage.
+    # @param content see {GeneratedPage#initialize}
+    # @param title_prefix see {GeneratedSite#initialize}
+    # @param body_element_tag see {GeneratedSite#initialize}
+    # @return [Hash<String, String>, String] the metadata hash containing the
+    #   `title`, `tags`, and `skip-index` elements; and the body content
+    #   stripped of boilerplate
+    def self.parse_generated_page(content, title_prefix, body_element_tag)
+      data = {}
+      head_element = self.parse_basic_tag 'head', content
+      return data, nil if head_element.nil?
+
+      title = self.parse_basic_tag 'title', head_element
+      if !title.nil? && title.start_with?(title_prefix)
+        title = title[title_prefix.size..title.size]
+      end
+      data['title'] = title
+      data.merge(self.parse_meta_tags head_element)
+      return data, self.parse_content_from_body(content, body_element_tag)
+    end
+
+    # Parses a value from content from between tags that cannot be nested,
+    # e.g. <head>, <body>, <title>.
+    # @param tag_name [String] name of the tag to parse
+    # @param content [String] HTML content from which to parse a value
+    # @return [String] if a value is successfully parsed
+    # @return [nil] if the tag isn't present in content, or is not well-formed
+    def self.parse_basic_tag(tag_name, content)
+      open_tag = "<#{tag_name}"
+      close_tag = "</#{tag_name}>"
+      open_i = content.index open_tag
+      return nil if open_i.nil?
+      open_i = content.index('>', open_i + open_tag.size) + 1
+      close_i = content.index close_tag, open_i
+      return nil if close_i.nil?
+      content[open_i..close_i-1]
+    end
+
+    # Parses the (name, content) pairs from <meta> tags in the <head> element.
+    # Note that it parses _only_ the `name` and `content` fields.
+    # @param head_element [String] <head> element from an HTML document
+    # @return [Hash<String, String>] a collection of (name, content) values
+    def self.parse_meta_tags(head_element)
+      open_tag = "<meta "
+      open_i = head_element.index open_tag
+      meta_tags = {}
+
+      until open_i.nil? do
+        open_i += open_tag.size
+        close_i = head_element.index '>', open_i
+        return if close_i.nil?
+
+        current = head_element[open_i..close_i]
+        attrs = {'name' => nil, 'content' => nil}
+
+        attrs.keys.each do |attr|
+          attr_begin = "#{attr}="
+          attr_begin_i = current.index attr_begin
+          unless attr_begin_i.nil?
+            attr_begin_i += attr_begin.size + 1
+            delim = current[attr_begin_i-1]
+            attr_end_i = current.index delim, attr_begin_i
+            next if attr_end_i.nil?
+            attr_end_i -= 1
+            attrs[attr] = current[attr_begin_i..attr_end_i]
+          end
+        end
+        meta_name = attrs['name']
+        meta_tags[meta_name] = attrs['content'] unless meta_name.nil?
+        close_i += 1
+        open_i = head_element.index open_tag, close_i
+      end
+      meta_tags
+    end
+
+    # Parse actual content from an HTML page, leaving out boilerplate.
+    # @param content [String] content of an HTML document
+    # @param body_element_tag see {GeneratedSite#initialize}
+    def self.parse_content_from_body(content, body_element_tag)
+      body = parse_basic_tag 'body', content
+      start_body = body.index body_element_tag
+      return body if start_body.nil?
+
+      start_body += 1
+      end_name_i = body.index ' ', start_body
+      bracket_i = body.index '>', start_body
+      end_name_i = bracket_i if bracket_i < end_name_i
+      tag_name = body[start_body..end_name_i-1]
+      open_tag = "<#{tag_name}"
+      end_tag = "</#{tag_name}>"
+
+      start_body = bracket_i + 1
+      search_i = start_body
+      open_tag_i = body.index open_tag, search_i
+      end_tag_i = body.index end_tag, search_i
+      depth = 1
+      until depth == 0
+        if end_tag_i.nil?
+          raise "End tag missing: #{end_tag}"
+        end
+        if !open_tag.nil? && open_tag_i < end_tag_i
+          depth += 1
+          search_i = open_tag_i + open_tag.size
+          open_tag_i = body.index open_tag, search_i
+        else
+          depth -= 1
+          search_i = end_tag_i + end_tag.size
+          end_tag_i = body.index end_tag, search_i unless depth == 0
+        end
+      end
+      body[start_body..end_tag_i-1]
+    end
+  end
+end

--- a/lib/jekyll_pages_api/generated_site.rb
+++ b/lib/jekyll_pages_api/generated_site.rb
@@ -16,9 +16,9 @@ module JekyllPagesApi
     # @param basedir [String] Path to the generated site's root directory
     # @param title_prefix [String] Prefix to strip from page titles
     # @param body_element_tag [String] Tag (or tag prefix) identifying the
-    #   main content element of each tag. Can be a complete tag (ending in
-    #   '>'), or the prefix of a longer tag. Used to strip boilerplate out of
-    #   the content exported via the API.
+    #   main content element within the <body> element of each document. Can
+    #   be a complete tag (ending in '>'), or the prefix of a longer tag. Used
+    #   to strip boilerplate out of the content exported via the API.
     def initialize(baseurl, basedir, title_prefix, body_element_tag)
       @baseurl = baseurl
       @basedir = basedir
@@ -33,8 +33,8 @@ module JekyllPagesApi
       Dir.glob(File.join(self.basedir, '**', '*')) do |f|
         next unless f.end_with? '.html'
         begin
-          page = GeneratedPage.new(self.basedir, self.title_prefix,
-            self.body_element_tag, f, File.read(f))
+          page = GeneratedPage.new(f, self.basedir, self.title_prefix,
+            self.body_element_tag, File.read(f))
           yield page unless page.data['title'].nil?
         rescue
           $stderr.puts "Error while processing #{f}:"

--- a/lib/jekyll_pages_api/generated_site.rb
+++ b/lib/jekyll_pages_api/generated_site.rb
@@ -1,0 +1,46 @@
+# @author Mike Bland (michael.bland@gsa.gov)
+
+require_relative 'generated_page'
+
+module JekyllPagesApi
+  # Used by the standalone executable to mimic a Jekyll::Site when processing
+  # an already-generated site using the Generator.
+  class GeneratedSite
+    # @see #initialize
+    attr_reader :baseurl, :basedir, :title_prefix, :body_element_tag
+
+    # @return [Array<>] a dummy empty Array
+    attr_accessor :pages
+
+    # @param baseurl [String] URL prefix of every page of the generated site
+    # @param basedir [String] Path to the generated site's root directory
+    # @param title_prefix [String] Prefix to strip from page titles
+    # @param body_element_tag [String] Tag (or tag prefix) identifying the
+    #   main content element of each tag. Can be a complete tag (ending in
+    #   '>'), or the prefix of a longer tag. Used to strip boilerplate out of
+    #   the content exported via the API.
+    def initialize(baseurl, basedir, title_prefix, body_element_tag)
+      @baseurl = baseurl
+      @basedir = basedir
+      @title_prefix = title_prefix
+      @body_element_tag = body_element_tag
+      @pages = []
+    end
+
+    # Generator yielding each HTML page (as a {GeneratedPage}) that should be
+    # exported via the API.
+    def each_site_file
+      Dir.glob(File.join(self.basedir, '**', '*')) do |f|
+        next unless f.end_with? '.html'
+        begin
+          page = GeneratedPage.new(self.basedir, self.title_prefix,
+            self.body_element_tag, f, File.read(f))
+          yield page unless page.data['title'].nil?
+        rescue
+          $stderr.puts "Error while processing #{f}:"
+          raise
+        end
+      end
+    end
+  end
+end

--- a/spec/generated_page_parser_spec.rb
+++ b/spec/generated_page_parser_spec.rb
@@ -1,0 +1,181 @@
+module JekyllPagesApi
+  describe GeneratedPageParser do
+    describe '#parse_basic_tag' do
+      it "returns nil if content is empty" do
+        expect(GeneratedPageParser.parse_basic_tag('', '')).to eq(nil)
+      end
+
+      it "returns nil if the tag is not present" do
+        expect(GeneratedPageParser.parse_basic_tag(
+          'title', 'foobar')).to eq(nil)
+      end
+
+      it "returns nil if the tag is not closed" do
+        expect(GeneratedPageParser.parse_basic_tag(
+          'title', '<title>foobar')).to eq(nil)
+      end
+
+      it "returns the content of the tag" do
+        expect(GeneratedPageParser.parse_basic_tag(
+          'title', '<title>foobar</title>')).to eq('foobar')
+      end
+    end
+
+    describe '#parse_meta_tags' do
+      it "returns an empty hash if the head_element is empty" do
+        expect(GeneratedPageParser.parse_meta_tags('')).to eq({})
+      end
+
+      it "returns an empty hash if a meta tag isn't closed properly" do
+        expect(GeneratedPageParser.parse_meta_tags(
+          '<meta name="foo" content="bar"')).to eq({})
+      end
+
+      it "returns an empty hash if the only meta tag lacks a name" do
+        expect(GeneratedPageParser.parse_meta_tags(
+          '<meta not_a_name="foo" content="bar">')).to eq({})
+      end
+
+      it "returns a valid hash for a well-formed meta tag" do
+        expect(GeneratedPageParser.parse_meta_tags(
+          '<meta name="foo" content="bar">')).to eq("foo" => "bar")
+      end
+
+      it "returns a valid hash for a self-closing meta tag" do
+        expect(GeneratedPageParser.parse_meta_tags(
+          '<meta name="foo" content="bar"/>')).to eq("foo" => "bar")
+      end
+
+      it "returns a valid hash for a meta tag with single-quote delimiters" do
+        expect(GeneratedPageParser.parse_meta_tags(
+          "<meta name='foo' content='bar'/>")).to eq("foo" => "bar")
+      end
+
+      it "returns a valid hash for a meta tag with mixed-quote delimiters" do
+        expect(GeneratedPageParser.parse_meta_tags(
+          "<meta name='foo' content=\"bar\"/>")).to eq("foo" => "bar")
+      end
+
+      it "returns a valid hash regardless of attribute order" do
+        expect(GeneratedPageParser.parse_meta_tags(
+          '<meta content="bar" name="foo" />')).to eq("foo" => "bar")
+      end
+
+      it "returns a valid hash for multiple meta tags" do
+        expect(GeneratedPageParser.parse_meta_tags(
+          '<meta name="foo" content="bar"/>'+
+          "<meta name='baz' content='quux' other=\"don't care\" >" +
+          '<meta content="plugh" name="xyzzy" />')
+          ).to eq("foo" => "bar", "baz" => "quux", "xyzzy" => "plugh")
+      end
+    end
+
+    describe '#parse_content_from_body' do
+      it "returns the empty string if passed all empty strings" do
+        expect(GeneratedPageParser.parse_content_from_body("", "")).to eq("")
+      end
+
+      it "returns the original content if there are no body tags" do
+        expect(GeneratedPageParser.parse_content_from_body(
+          "foobar", "")).to eq("foobar")
+      end
+
+      it "returns the original content if the body tag isn't closed" do
+        expect(GeneratedPageParser.parse_content_from_body(
+          "<body>foobar", "")).to eq("<body>foobar")
+      end
+
+      it "returns the full body content if the body_element_tag is empty" do
+        expect(GeneratedPageParser.parse_content_from_body(
+          "<body>header<div class='content'>foobar</div>footer</body>", "")
+          ).to eq("header<div class='content'>foobar</div>footer")
+      end
+
+      it "returns only the body content within the body_element_tag" do
+        expect(GeneratedPageParser.parse_content_from_body(
+          "<body><div>header</div>"+
+          "<div class='content'>foobar</div>"+
+          "<div>footer</div></body>",
+          "<div class='content'>")).to eq("foobar")
+      end
+
+      it "returns only the body content when body_element_tag is a prefix" do
+        expect(GeneratedPageParser.parse_content_from_body(
+          "<body><div>header</div>"+
+          "<div class='content' plus='blah blah woof woof'>foobar</div>"+
+          "<div>footer</div></body>",
+          "<div class='content'")).to eq("foobar")
+      end
+
+      it "handles nested divs within the body content" do
+        expect(GeneratedPageParser.parse_content_from_body(
+          "<body><div>header</div>"+
+          "<div class='content' plus='blah blah woof woof'>"+
+          "blah blah"+
+          "<div>plus<div>some</div><div>nested</div>divs</div>"+
+          "woof woof"+
+          "</div>"+
+          "<div>footer</div></body>",
+          "<div class='content'")
+        ).to eq(
+          "blah blah"+
+          "<div>plus<div>some</div><div>nested</div>divs</div>"+
+          "woof woof"
+        )
+      end
+    end
+
+    describe '#parse_generated_page' do
+      it "returns empty values when passed all empty strings" do
+        data, content = GeneratedPageParser.parse_generated_page "", "", ""
+        expect(data).to eq({})
+        expect(content).to eq("")
+      end
+
+      it "returns empty values when the head element isn't present" do
+        data, content = GeneratedPageParser.parse_generated_page(
+          "<body>foobar</body>", "", "")
+        expect(data).to eq({})
+        expect(content).to eq("")
+      end
+
+      it "returns a nil title and all body content" do
+        data, content = GeneratedPageParser.parse_generated_page(
+          "<head></head>"+
+          "<body><div>header</div>"+
+          "<div class='content'>foobar</div>"+
+          "<div>footer</div></body>", "", "")
+        expect(data).to eq({"title" => nil})
+        expect(content).to eq(
+          "<div>header</div><div class='content'>foobar</div><div>footer</div>")
+      end
+
+      it "returns the title and only body content within body_element_tag" do
+        data, content = GeneratedPageParser.parse_generated_page(
+          "<head><title>Blah Blah Woof Woof</title></head>"+
+          "<body><div>header</div>"+
+          "<div class='content'>foobar</div>"+
+          "<div>footer</div></body>", "", "<div class='content'")
+        expect(data).to eq({"title" => "Blah Blah Woof Woof"})
+        expect(content).to eq("foobar")
+      end
+
+      it "returns the stripped title body content and metadata" do
+        data, content = GeneratedPageParser.parse_generated_page(
+          "<head><title>18F &mdash; Blah Blah Woof Woof</title>"+
+          "<meta name='skip-index' content='true'>"+
+          "<meta content='baz,quux,xyzzy,plugh' name=\"tags\" />"+
+          "</head>"+
+          "<body><div>header</div>"+
+          "<div class='content'>foobar</div>"+
+          "<div>footer</div></body>", "18F &mdash; ", "<div class='content'")
+        expect(data).to eq(
+          "title" => "Blah Blah Woof Woof",
+          "skip-index" => "true",
+          "tags" => "baz,quux,xyzzy,plugh",
+        )
+        expect(content).to eq("foobar")
+      end
+    end
+  end
+end

--- a/spec/generated_page_spec.rb
+++ b/spec/generated_page_spec.rb
@@ -1,0 +1,86 @@
+module JekyllPagesApi
+  describe GeneratedPage do
+    describe '#initialize' do
+      it "handles all empty strings correctly" do
+        page = GeneratedPage.new "", "", "", "", ""
+        expect(page.path).to eq("")
+        expect(page.relative_path).to eq("")
+        expect(page.data).to eq({})
+        expect(page.content).to eq("")
+      end
+
+      it "parses the relative path when basedir ends in SEPARATOR" do
+        path = File.join "foo", "bar", "baz.html"
+        basedir = File.join "foo", ""
+        page = GeneratedPage.new path, basedir, "", "", ""
+        expect(page.path).to eq("foo/bar/baz.html")
+        expect(page.relative_path).to eq("/bar/baz.html")
+        expect(page.data).to eq({})
+        expect(page.content).to eq("")
+      end
+
+      it "parses the relative path when basedir doesn't end in SEPARATOR" do
+        path = File.join "foo", "bar", "baz.html"
+        basedir = "foo"
+        page = GeneratedPage.new path, basedir, "", "", ""
+        expect(page.path).to eq("foo/bar/baz.html")
+        expect(page.relative_path).to eq("/bar/baz.html")
+        expect(page.data).to eq({})
+        expect(page.content).to eq("")
+      end
+
+      it "raises RuntimeError when path does not begin with basedir" do
+        path = File.join "foo", "bar", "baz.html"
+        basedir = File.join "quux", ""
+        expect{GeneratedPage.new path, basedir, "", "", ""
+          }.to raise_error(
+            RuntimeError, "#{path} does not start with #{basedir}")
+      end
+
+      it "parses out index.html suffix and leaves trailing slash" do
+        path = File.join "foo", "bar", "index.html"
+        basedir = File.join "foo", ""
+        page = GeneratedPage.new path, basedir, "", "", ""
+        expect(page.path).to eq("foo/bar/index.html")
+        expect(page.relative_path).to eq("/bar/")
+        expect(page.data).to eq({})
+        expect(page.content).to eq("")
+      end
+
+      it "parses out index.html suffix and leaves trailing slash for root" do
+        path = File.join "foo", "index.html"
+        basedir = File.join "foo", ""
+        page = GeneratedPage.new path, basedir, "", "", ""
+        expect(page.path).to eq("foo/index.html")
+        expect(page.relative_path).to eq("/")
+        expect(page.data).to eq({})
+        expect(page.content).to eq("")
+      end
+
+      it "parses content correctly" do
+        path = File.join "foo", "bar", "index.html"
+        basedir = File.join "foo", ""
+        title_prefix = "18F &mdash; "
+        body_element_tag = "<div class='content'"
+        content = "<head><title>18F &mdash; Blah Blah Woof Woof</title>"+
+          "<meta name='skip-index' content='true'>"+
+          "<meta content='baz,quux,xyzzy,plugh' name=\"tags\" />"+
+          "</head>"+
+          "<body><div>header</div>"+
+          "<div class='content'>foobar</div>"+
+          "<div>footer</div></body>"
+
+        page = GeneratedPage.new(path, basedir, title_prefix,
+          body_element_tag, content)
+        expect(page.path).to eq("foo/bar/index.html")
+        expect(page.relative_path).to eq("/bar/")
+        expect(page.data).to eq(
+          "title" => "Blah Blah Woof Woof",
+          "skip-index" => "true",
+          "tags" => "baz,quux,xyzzy,plugh",
+        )
+        expect(page.content).to eq("foobar")
+      end
+    end
+  end
+end

--- a/spec/generated_site_spec.rb
+++ b/spec/generated_site_spec.rb
@@ -1,0 +1,58 @@
+require 'fileutils'
+require 'tmpdir'
+
+module JekyllPagesApi
+  describe GeneratedPage do
+    describe '#each_site_file' do
+      before :each do
+        @test_tmpdir = Dir.mktmpdir
+      end
+
+      after :each do
+        FileUtils.remove_entry @test_tmpdir
+      end
+
+      it "should only select .html files containing a title" do
+        basedir = File.join @test_tmpdir, "foo"
+        FileUtils.mkdir_p basedir
+
+        content_dir = File.join(basedir, "bar")
+        FileUtils.mkdir_p content_dir
+
+        File.open(File.join(content_dir, "baz.txt"), "w") do |f|
+          f << "Text file that should be excluded."
+        end
+
+        File.open(File.join(content_dir, "quux.html"), "w") do |f|
+          f << "<html><head><title>18F &mdash; Include me!</title></head>"
+          f << "<body><div>header</div>"
+          f << "<div class='content'>This page should be included.</div>"
+          f << "<div>footer</div></body></html>"
+        end
+
+        File.open(File.join(content_dir, "xyzzy.html"), "w") do |f|
+          f << "<html><head></head><body>"
+          f << "This page shouldn't be included because it lacks a title."
+          f << "</body></html>"
+        end
+
+        paths = ['baz.txt', 'quux.html', 'xyzzy.html'].sort.map do |f|
+          File.join content_dir, f
+        end
+        expect(Dir.glob(File.join(content_dir, '**', '*'))).to eq(paths)
+
+        site = GeneratedSite.new("https://unused/", basedir,
+          "18F &mdash; ", "<div class='content'")
+        pages = []
+        site.each_site_file {|f| pages << f}
+        expect(pages.size).to eq(1)
+
+        page = pages.first
+        expect(page.path).to eq(File.join content_dir, 'quux.html')
+        expect(page.relative_path).to eq("/bar/quux.html")
+        expect(page.data).to eq("title" => "Include me!")
+        expect(page.content).to eq("This page should be included.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Needs some refactoring, tests, better input handling and documentation, but is a functional proof-of-concept. Built a nearly-equivalent index using:

```shell
$ bundle exec bin/jekyll_pages_api "" ../hub/_site \
  "18F &mdash; " '<div class="bare-content" ' > out.txt
```

I say "nearly-equivalent" because in the new version, URLs don't have trailing slashes, and the "Edit this link" text appears at the end of the body. We can update the layout to trim the latter. Also, files without titles aren't included, such as the auth-include snippets.

cc: @afeld