### PR TITLE
Explained adding ruby server to Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ group :jekyll_plugins do
 end
 ```
 
+If you're creating a new Gemfile in your Jekyll project, make sure to include a source at the top:
+
+```ruby
+source 'https://rubygems.org'
+```
+
 And then execute:
 
 ```bash


### PR DESCRIPTION
* Jekyll projects are not built with a Gemfile by default
* When adding the jekyll-pages-api gem to the gemfile bundler will fail without the ruby server listed at the top