### PR TITLE
add meta field to json

### DIFF
--- a/lib/jekyll_pages_api/page.rb
+++ b/lib/jekyll_pages_api/page.rb
@@ -52,6 +52,10 @@ module JekyllPagesApi
       (self.page.data['tags'] if self.page.respond_to?(:data)) || []
     end
 
+    def meta
+      (self.page.data['meta'] if self.page.respond_to?(:data)) || []
+    end
+
     def skip_index?
       (self.page.data['skip_index'] if self.page.respond_to?(:data)) || false
     end
@@ -63,6 +67,7 @@ module JekyllPagesApi
         title: self.title,
         url: self.url,
         tags: self.tags,
+        meta: self.meta,
         body: self.body_text
       })
     end

--- a/lib/jekyll_pages_api/page.rb
+++ b/lib/jekyll_pages_api/page.rb
@@ -53,7 +53,7 @@ module JekyllPagesApi
     end
 
     def meta
-      (self.page.data['meta'] if self.page.respond_to?(:data)) || []
+      (self.page.data['meta'] if self.page.respond_to?(:data)) || {}
     end
 
     def skip_index?


### PR DESCRIPTION
Enables to add meta field to JSON.

```

---
title: hello
meta:
  address: Tokyo, Japan
  lat: xxxxxx
  lng: yyyyyy

---

Hello Tokyo
```

Then:

```
{
  "entries": [
    {
      "title": "hello",
      "url": "/2016/04/18/example.html",
      "tags": [],
      "meta": {
        "address": "Tokyo, Japan",
        "lat": "xxxxxx",
        "lng": "yyyyyy"
      },
      "body": "Hello Tokyo"
    }
  ]
}
```

Thanks!
