### PR TITLE
Handle unsorted glob in the tests

### DIFF
--- a/spec/generated_site_spec.rb
+++ b/spec/generated_site_spec.rb
@@ -39,8 +39,7 @@ module JekyllPagesApi
         paths = ['baz.txt', 'quux.html', 'xyzzy.html'].sort.map do |f|
           File.join content_dir, f
         end
-        expect(Dir.glob(File.join(content_dir, '**', '*'))).to contain_exactly(
-          *paths)
+        expect(Dir.glob(File.join(content_dir, '**', '*'))).to match_array(paths)
 
         site = GeneratedSite.new("https://unused/", basedir,
           "18F &mdash; ", "<div class='content'")

--- a/spec/generated_site_spec.rb
+++ b/spec/generated_site_spec.rb
@@ -39,7 +39,8 @@ module JekyllPagesApi
         paths = ['baz.txt', 'quux.html', 'xyzzy.html'].sort.map do |f|
           File.join content_dir, f
         end
-        expect(Dir.glob(File.join(content_dir, '**', '*'))).to eq(paths)
+        expect(Dir.glob(File.join(content_dir, '**', '*'))).to contain_exactly(
+          *paths)
 
         site = GeneratedSite.new("https://unused/", basedir,
           "18F &mdash; ", "<div class='content'")


### PR DESCRIPTION
The `Dir.glob` method produces files in an OS-dependent sorting order;
in fact, the order is undefined. Use the `#contain_exactly` matcher
instead of `#eq` to handle this situation.
