### PR TITLE
Add frontmatter to the JSON result

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,14 @@ You can then see the generated JSON file at http://localhost:4000/api/v1/pages.j
       // the page path
       "url": "/",
       // the content of the page, with the HTML tags stripped and the whitespace condensed
-      "body": "18F is a digital services team within GSA..."
+      "body": "18F is a digital services team within GSA...",
+      "meta": {
+        // all the frontmatter for the page
+        "title": "18F Hub",
+        "url": "/",
+        "layout": "page",
+        "permalink": "/",
+      }
     },
     // ...
   ]

--- a/lib/jekyll_pages_api/page.rb
+++ b/lib/jekyll_pages_api/page.rb
@@ -59,11 +59,13 @@ module JekyllPagesApi
     def to_json
       optional = {}
       optional['skip_index'] = true if self.skip_index?
+
       optional.merge({
         title: self.title,
         url: self.url,
         tags: self.tags,
-        body: self.body_text
+        body: self.body_text,
+        meta: self.page.data
       })
     end
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -97,6 +97,8 @@ describe "integration" do
     expect(page['meta']['layout']).to eq("page")
     expect(page['meta']['permalink']).to eq("/about/")
     expect(page['meta']['skip_index']).to eq(true)
+    expect(page['meta']['tags']).to eq(["Jekyll", "test page", "convenient"])
+    expect(page['meta']['title']).to eq("About")
   end
 
   it "sets skip_index only if it is true" do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -94,6 +94,9 @@ describe "integration" do
   it "includes front matter tags" do
     page = page_data('/about/')
     expect(page['tags']).to eq(["Jekyll", "test page", "convenient"])
+    expect(page['meta']['layout']).to eq("page")
+    expect(page['meta']['permalink']).to eq("/about/")
+    expect(page['meta']['skip_index']).to eq(true)
   end
 
   it "sets skip_index only if it is true" do


### PR DESCRIPTION
This adds all the frontmatter to the JSON result under the `meta` key.

Closes #11.
